### PR TITLE
Update VertxSessionStore.java

### DIFF
--- a/src/main/java/org/pac4j/vertx/context/session/VertxSessionStore.java
+++ b/src/main/java/org/pac4j/vertx/context/session/VertxSessionStore.java
@@ -53,7 +53,8 @@ public class VertxSessionStore implements ExtendedSessionStore<VertxWebContext> 
 
     @Override
     public boolean renewSession(VertxWebContext context) {
-        return false;
+        context.vertxSession.regenerateId();
+        return true;
     }
 
     @Override


### PR DESCRIPTION
VertxSessionStore can renew the session.It can fix `logger.error("Unable to renew the session. The session store may not support this feature");` in `org.pac4j.core.engine.DefaultCallbackLogic`